### PR TITLE
Update file duplication check

### DIFF
--- a/AssetDownloader.sln
+++ b/AssetDownloader.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E192B2D5-FB5D-433D-A26B-5F845E329D6E}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/AssetDownloader/Constants.cs
+++ b/AssetDownloader/Constants.cs
@@ -31,4 +31,10 @@ public static class Constants
             "-p <platform>" or "--platform <platform>": Sets the version of assets to download.
                 Valid options: Android, iOS (default: Android)
         """;
+
+    public const string JpManifest = "assetbundle.manifest.json";
+    public const string EuManifest = "assetbundle.en_eu.manifest.json";
+    public const string EnManifest = "assetbundle.en_us.manifest.json";
+    public const string CnManifest = "assetbundle.zh_cn.manifest.json";
+    public const string TwManifest = "assetbundle.zh_tw.manifest.json";
 }

--- a/AssetDownloader/Downloader.cs
+++ b/AssetDownloader/Downloader.cs
@@ -95,15 +95,7 @@ public class Downloader
 
             while (_downloadedAssets + _failedAssets.Count != totalAssets)
             {
-                await Console.Out.WriteAsync(
-                    " - Download progress: "
-                        + $"{Utils.GetHumanReadableFilesize(_downloadedBytes, 6)}/{totalBytesString} MB, "
-                        + $"({_downloadedAssets}/{totalAssets}) Assets, "
-                        + $"{Utils.GetFormattedPercent(_downloadedAssets, totalAssets)} "
-                        + $"({stopwatch.Elapsed:hh\\:mm\\:ss})"
-                        + "              \r"
-                );
-
+                await this.WriteProgress(totalBytesString, totalAssets, stopwatch.Elapsed);
                 await Task.Delay(10);
             }
 
@@ -122,11 +114,28 @@ public class Downloader
                     "Concurrency has been set to one thread for the remaining downloads."
                 );
             }
+            else
+            {
+                // On exiting loop, update progress so it does not imply files have been missed
+                await this.WriteProgress(totalBytesString, totalAssets, stopwatch.Elapsed);
+            }
         } while (!_failedAssets.IsEmpty);
 
         stopwatch.Stop();
         await Console.Out.WriteLineAsync(
             $"\nAsset download completed. Time elapsed: {stopwatch.Elapsed:hh\\:mm\\:ss}"
+        );
+    }
+
+    private async Task WriteProgress(string totalBytesString, int totalAssets, TimeSpan elapsed)
+    {
+        await Console.Out.WriteAsync(
+            " - Download progress: "
+                + $"{Utils.GetHumanReadableFilesize(_downloadedBytes, 6)}/{totalBytesString} MB, "
+                + $"({_downloadedAssets}/{totalAssets}) Assets, "
+                + $"{Utils.GetFormattedPercent(_downloadedAssets, totalAssets)} "
+                + $"({elapsed:hh\\:mm\\:ss})"
+                + "              \r"
         );
     }
 

--- a/AssetDownloader/FilenameEqualityComparer.cs
+++ b/AssetDownloader/FilenameEqualityComparer.cs
@@ -1,0 +1,10 @@
+using AssetDownloader.Models;
+
+namespace AssetDownloader;
+
+public class FilenameEqualityComparer : IEqualityComparer<AssetInfo>
+{
+    public bool Equals(AssetInfo? x, AssetInfo? y) => x?.Name == y?.Name;
+
+    public int GetHashCode(AssetInfo obj) => obj.Name.GetHashCode();
+}

--- a/AssetDownloader/HashEqualityComparer.cs
+++ b/AssetDownloader/HashEqualityComparer.cs
@@ -1,0 +1,10 @@
+using AssetDownloader.Models;
+
+namespace AssetDownloader;
+
+public class HashEqualityComparer : IEqualityComparer<AssetInfo>
+{
+    public bool Equals(AssetInfo? x, AssetInfo? y) => x?.Hash == y?.Hash;
+
+    public int GetHashCode(AssetInfo obj) => obj.Hash.GetHashCode();
+}

--- a/AssetDownloader/Models/Arguments.cs
+++ b/AssetDownloader/Models/Arguments.cs
@@ -34,7 +34,7 @@ public class Arguments
             Output folder: {Path.Join(Directory.GetCurrentDirectory(), this.OutputFolder)}
             Skip old assets: {this.SkipOldAssets}
             Download English: {this.DownloadEn}
-            Download EU English: {this.DownloadEu}
+            Download international English: {this.DownloadEu}
             Download Chinese: {this.DownloadCn}
             Download Taiwanese: {this.DownloadTw}
             Maximum concurrent downloads: {this.MaxConcurrent}

--- a/AssetDownloader/Models/Manifest.cs
+++ b/AssetDownloader/Models/Manifest.cs
@@ -44,14 +44,4 @@ public class AssetInfo
         HashBytes = Base32.ToBytes(hash);
         DownloadPath = $"{HashId}/{hash}";
     }
-
-    public override bool Equals(object? obj)
-    {
-        return obj is AssetInfo asset && this.Name == asset.Name;
-    }
-
-    public override int GetHashCode()
-    {
-        return this.Name.GetHashCode();
-    }
 }

--- a/AssetDownloader/Models/Manifest.cs
+++ b/AssetDownloader/Models/Manifest.cs
@@ -4,7 +4,8 @@ public class Manifest
 {
     public List<AssetCategory> Categories { get; }
     public List<AssetInfo> RawAssets { get; }
-    public IEnumerable<AssetInfo> AllAssets => Categories.SelectMany(c => c.Assets).Concat(RawAssets);
+    public IEnumerable<AssetInfo> AllAssets =>
+        Categories.SelectMany(c => c.Assets).Concat(RawAssets);
 
     public Manifest(List<AssetCategory> categories, List<AssetInfo> rawAssets)
     {
@@ -46,11 +47,11 @@ public class AssetInfo
 
     public override bool Equals(object? obj)
     {
-        return obj is AssetInfo asset && Hash == asset.Hash;
+        return obj is AssetInfo asset && this.Name == asset.Name;
     }
 
     public override int GetHashCode()
     {
-        return Hash.GetHashCode();
+        return this.Name.GetHashCode();
     }
 }

--- a/AssetDownloader/Program.cs
+++ b/AssetDownloader/Program.cs
@@ -29,12 +29,14 @@ if (!parsedArgs.IsValid)
     Utils.FriendlyExit();
 }
 
-if (!parsedArgs.SkipOldAssets && parsedArgs.PlatformName == Constants.Ios)
+if (parsedArgs is { SkipOldAssets: false, PlatformName: Constants.Ios })
 {
     Console.WriteLine(
         "Error: Cannot download all iOS assets as only the latest manifest has been preserved."
     );
-    Console.WriteLine("Please use the --skip-old-assets flag to acknowledge this issue.");
+    Console.WriteLine(
+        "Please use the --skip-old-assets flag or select 'n' to the first question to acknowledge this issue."
+    );
     Utils.FriendlyExit();
 }
 
@@ -52,8 +54,6 @@ else
     await Console.Out.WriteLineAsync("Found existing manifests. Skipping download.");
 }
 
-// Collect all hashes
-HashSet<AssetInfo> hashes = new();
 await Console.Out.WriteLineAsync("\nParsing manifests...");
 
 var manifestPath = Path.Combine(
@@ -78,43 +78,49 @@ var manifestDirs = parsedArgs.SkipOldAssets
 
 await Console.Out.WriteLineAsync("Starting manifest parsing.");
 
+// Collect all hashes
+Dictionary<string, HashSet<AssetInfo>> localeHashmaps =
+    new() { { Constants.JpManifest, new HashSet<AssetInfo>() } };
+
+// Separate hashmaps per localisation to avoid overwriting across languages
+if (parsedArgs.DownloadEn)
+    localeHashmaps.Add(Constants.EnManifest, new HashSet<AssetInfo>());
+if (parsedArgs.DownloadEu)
+    localeHashmaps.Add(Constants.EuManifest, new HashSet<AssetInfo>());
+if (parsedArgs.DownloadCn)
+    localeHashmaps.Add(Constants.CnManifest, new HashSet<AssetInfo>());
+if (parsedArgs.DownloadTw)
+    localeHashmaps.Add(Constants.TwManifest, new HashSet<AssetInfo>());
+
 for (int i = 0; i < manifestDirs.Count; i++)
 {
-    var directory = manifestDirs.ElementAt(i);
-    var manifestName = directory.Name.Split("_")[1];
+    var currentManifestDir = manifestDirs.ElementAt(i);
+    var manifestName = currentManifestDir.Name.Split("_")[1];
 
     await Console.Out.WriteAsync(
         $" - Parsing manifest {manifestName} ({i + 1}/{manifestDirs.Count})             \r"
     );
 
-    List<string> paths = new() { Path.Combine(directory.FullName, "assetbundle.manifest.json") };
-
-    if (parsedArgs.DownloadEu)
-        paths.Add(Path.Combine(directory.FullName, "assetbundle.en_eu.manifest.json"));
-
-    if (parsedArgs.DownloadEn)
-        paths.Add(Path.Combine(directory.FullName, "assetbundle.en_us.manifest.json"));
-
-    if (parsedArgs.DownloadCn)
-        paths.Add(Path.Combine(directory.FullName, "assetbundle.zh_cn.manifest.json"));
-
-    if (parsedArgs.DownloadTw)
-        paths.Add(Path.Combine(directory.FullName, "assetbundle.zh_tw.manifest.json"));
-
-    foreach (string path in paths)
+    foreach ((string filename, HashSet<AssetInfo> assetCollection) in localeHashmaps)
     {
-        var m =
+        string path = Path.Join(currentManifestDir.FullName, filename);
+        Manifest m =
             JsonConvert.DeserializeObject<Manifest>(File.ReadAllText(path))
-            ?? throw new JsonException("JSON deserialization failed.");
+            ?? throw new NullReferenceException("JSON deserialization failure");
 
-        hashes.UnionWith(m.AllAssets);
+        assetCollection.UnionWith(m.AllAssets);
     }
 }
+
+// Combine disparate hashmaps
+List<AssetInfo> finalAssets = new();
+foreach ((string _, HashSet<AssetInfo> assetCollection) in localeHashmaps)
+    finalAssets.AddRange(assetCollection);
 
 await Console.Out.WriteLineAsync("\nFinished manifest parsing.\n");
 
 var downloader = new Downloader(
-    hashes,
+    finalAssets,
     parsedArgs.OutputFolder,
     parsedArgs.PlatformName,
     parsedArgs.MaxConcurrent

--- a/AssetDownloader/Program.cs
+++ b/AssetDownloader/Program.cs
@@ -66,35 +66,30 @@ var manifestPath = Path.Combine(
     parsedArgs.PlatformName
 );
 
-var manifestDirs = parsedArgs.SkipOldAssets
-    ? new List<DirectoryInfo>
-    {
-        new(
-            Path.Join(
-                manifestPath,
-                parsedArgs.PlatformName == Constants.Android
-                    ? Constants.LatestAndroidManifestName
-                    : Constants.LatestIosManifestName
-            )
-        )
-    }
-    : new DirectoryInfo(manifestPath).GetDirectories().OrderByDescending(x => x.Name).ToList();
+var manifestDirs = new DirectoryInfo(manifestPath)
+    .GetDirectories()
+    .OrderByDescending(x => x.Name)
+    .ToList();
+
+IEqualityComparer<AssetInfo> equalityComparer = parsedArgs.SkipOldAssets
+    ? new FilenameEqualityComparer()
+    : new HashEqualityComparer();
 
 await Console.Out.WriteLineAsync("Starting manifest parsing.");
 
 // Collect all hashes
 Dictionary<string, HashSet<AssetInfo>> localeHashmaps =
-    new() { { Constants.JpManifest, new HashSet<AssetInfo>() } };
+    new() { { Constants.JpManifest, new HashSet<AssetInfo>(equalityComparer) } };
 
 // Separate hashmaps per localisation to avoid overwriting across languages
 if (parsedArgs.DownloadEn)
-    localeHashmaps.Add(Constants.EnManifest, new HashSet<AssetInfo>());
+    localeHashmaps.Add(Constants.EnManifest, new HashSet<AssetInfo>(equalityComparer));
 if (parsedArgs.DownloadEu)
-    localeHashmaps.Add(Constants.EuManifest, new HashSet<AssetInfo>());
+    localeHashmaps.Add(Constants.EuManifest, new HashSet<AssetInfo>(equalityComparer));
 if (parsedArgs.DownloadCn)
-    localeHashmaps.Add(Constants.CnManifest, new HashSet<AssetInfo>());
+    localeHashmaps.Add(Constants.CnManifest, new HashSet<AssetInfo>(equalityComparer));
 if (parsedArgs.DownloadTw)
-    localeHashmaps.Add(Constants.TwManifest, new HashSet<AssetInfo>());
+    localeHashmaps.Add(Constants.TwManifest, new HashSet<AssetInfo>(equalityComparer));
 
 for (int i = 0; i < manifestDirs.Count; i++)
 {

--- a/AssetDownloader/Program.cs
+++ b/AssetDownloader/Program.cs
@@ -14,7 +14,7 @@ AppDomain.CurrentDomain.UnhandledException += (_, args) =>
 Arguments parsedArgs = Utils.VerifyArguments(args);
 if (!parsedArgs.IsValid)
 {
-    Console.WriteLine("Detected invalid command-line arguments. Starting interactive mode...");
+    Console.WriteLine("Could not read command-line arguments. Starting interactive mode...");
     parsedArgs = Utils.InteractiveArgs();
 }
 
@@ -42,6 +42,10 @@ if (parsedArgs is { SkipOldAssets: false, PlatformName: Constants.Ios })
 
 Console.WriteLine($"You have chosen the following options:{Environment.NewLine}");
 Console.WriteLine($"{parsedArgs}{Environment.NewLine}");
+Console.WriteLine(
+    "Press Enter to begin the download, or restart the program if you wish to choose different options."
+);
+Console.ReadLine();
 
 // Download and unzip dl-datamine repository
 if (!Directory.Exists(Constants.ClonedRepoFolder))

--- a/AssetDownloader/Utils.cs
+++ b/AssetDownloader/Utils.cs
@@ -103,7 +103,8 @@ public static class Utils
         Arguments result = new();
 
         result.SkipOldAssets = InputPromptBool(
-            "Skip old assets? This will reduce the size of the download by only keeping the newest version of each files, skipping e.g. pre-2.0 models"
+            "Do you want to only download the most recent version of each asset (cuts download from ~50GB to ~15GB)?"
+                + "\nThis option is not recommended unless you have no space for the full download. It may make it difficult to access old event data."
         );
 
         string outputFolder = InputPromptString(

--- a/AssetDownloader/Utils.cs
+++ b/AssetDownloader/Utils.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO.Compression;
 using System.Net.Http.Handlers;
 using AssetDownloader.Models;
@@ -104,10 +103,11 @@ public static class Utils
         Arguments result = new();
 
         result.SkipOldAssets = InputPromptBool(
-            "Skip old assets? This will reduce the size of the download, but you will not have files for older events."
+            "Skip old assets? This will reduce the size of the download by only keeping the newest version of each files, skipping e.g. pre-2.0 models"
         );
+
         string outputFolder = InputPromptString(
-            "Filepath for download result: (default: DownloadOutput)"
+            $"Filepath for download result: (leave blank for ./DownloadOutput)"
         );
 
         if (string.IsNullOrWhiteSpace(outputFolder))
@@ -115,10 +115,13 @@ public static class Utils
 
         result.OutputFolder = outputFolder;
 
-        result.MaxConcurrent = InputPromptInt("Maximum concurrent downloads (default: 16)", 16);
+        result.MaxConcurrent = InputPromptInt(
+            "Maximum concurrent downloads (leave blank for 16)",
+            16
+        );
 
         string platform = InputPromptString(
-            "Target asset platform? (allowed values: 'iOS', 'Android', default: Android)"
+            "Target asset platform? (allowed values: 'iOS', 'Android', leave blank for Android)"
         );
         result.PlatformName = platform.ToLower() switch
         {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ﻿# Dragalia Lost Asset Downloader
 
+## Requirements
+
+- [.NET 7 Runtime](https://dotnet.microsoft.com/en-us/download) installed
+
+
 Download from the [releases page](https://github.com/SapiensAnatis/AssetDownloader/releases/latest)
 
 NOTE: On newer versions of OS X, app signing requirements may prevent you from running the binary directly. If you encounter issues, download the source code and the .NET SDK, and use `dotnet run AssetDownloader.csproj`.
@@ -11,10 +16,6 @@ Using archived file manifests, this program constructs URLs to the Dragalia Lost
 The expected download size, depending on the enabled localisations, is about 16GB.
 
 The program's main responsibility is to fetch the manifest JSON, parse it, and download the contained files. This tool is capable of resuming a partially-completed manifest download and it will also parallelize the downloads.
-
-## Requirements
-
-- [.NET 7 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed 
 
 ## Configuration
 


### PR DESCRIPTION
- Updated README
- Updated prompts to be more user-friendly to those without CLI experience, and various other text fixes
- Updated asset duplication checking to check based on filename again, but avoid deduplicating across localisations
- Attempt to fix issue with failure loop due to timeout on large failed files -- when we retry, set concurrent downloads to 1. Default HttpClient timeout increased to 5 minutes from 100 seconds.